### PR TITLE
Added icon for number of sources representing popularity

### DIFF
--- a/src/components/AntiPatternCardComponent.vue
+++ b/src/components/AntiPatternCardComponent.vue
@@ -3,6 +3,13 @@
         <v-card-title class="primary white--text"
                       v-bind:style="{ background: 'linear-gradient(90deg, #3f51b5 98%, ' + referenceMedianColor + ' 2%) !important'}">
             <div class="headline">{{antiPattern.name}}</div>
+            <v-spacer></v-spacer>
+            <v-tooltip top>
+                <v-icon dark slot="activator">
+                    {{uiUtils.getIconForSources(antiPattern.sources.length)}}
+                </v-icon>
+                <span>Antipattern has {{antiPattern.sources.length}} sources</span>
+            </v-tooltip>
         </v-card-title>
         <v-card-text class="grow">
             <div>{{antiPattern.description}}</div>
@@ -29,6 +36,7 @@
     import AntiPatternActionsComponent from "./AntiPatternActionsComponent";
     import AntiPatternDetailComponent from "./AntiPatternDetailComponent";
     import EvidenceService from "../services/EvidenceService";
+    import UiUtils from "@/utils/UiUtils";
 
     @Component({
         components: {
@@ -39,6 +47,7 @@
     export default class AntiPatternCardComponent extends Vue {
         @Prop(Object) public antiPattern!: AntiPattern;
         public dialog: boolean = false;
+        public uiUtils = UiUtils;
 
         public get referenceMedianColor(): string {
             return EvidenceService.getReferenceMedianColor(this.antiPattern);

--- a/src/components/AntiPatternsContainerComponent.vue
+++ b/src/components/AntiPatternsContainerComponent.vue
@@ -35,6 +35,9 @@
                 });
                 this.antiPatterns.sort((a1, a2) => a2!.median! - a1!.median!);
             }
+            if (sorting.match("sources.*")) {
+                this.antiPatterns.sort((a1, a2) => a2!.sources!.length - a1!.sources!.length);
+            }
             if (sorting.match(".*Reverse")) {
                 this.antiPatterns.reverse();
             }

--- a/src/utils/UiUtils.ts
+++ b/src/utils/UiUtils.ts
@@ -1,0 +1,13 @@
+export default class UiUtils {
+
+    public static getIconForSources(sourceCount: number) {
+        if (!sourceCount || sourceCount === 0) {
+            return "warning";
+        } else if (sourceCount < 9) {
+            return "filter_" + sourceCount;
+        } else {
+            return "filter_9_plus";
+        }
+    }
+
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -85,6 +85,8 @@
             {name: "name: Z-A", value: "nameReverse"},
             {name: "evidence: high-low", value: "evidence"},
             {name: "evidence: low-high", value: "evidenceReverse"},
+            {name: "sources: many-few", value: "sources"},
+            {name: "sources: few-many", value: "sourcesReverse"},
         ];
 
         public get slot() {


### PR DESCRIPTION
After adding the evidence manually to the antipatterns we found out that often lots of sources meant that the evidence (median) is typically lower than for antipatterns with only a few or even a single source. However, the antipatterns with many sources are more popular which should somehow be represented as well. Therefore, we thought about adding icons to the antipatterns card titles, showing the popularity of the antipattern (number of sources). The number of sources has also been added as an sort option.

![image](https://user-images.githubusercontent.com/15340757/51322532-f7a02f00-1a65-11e9-9188-ad6b756cbb8c.png)
