### PR TITLE
Changed the color scheme

### DIFF
--- a/src/components/AntiPatternCardComponent.vue
+++ b/src/components/AntiPatternCardComponent.vue
@@ -1,7 +1,7 @@
 <template>
     <v-card style="display: flex; flex-direction: column;" height="100%">
         <v-card-title class="primary white--text"
-                      v-bind:style="{ background: 'linear-gradient(90deg, #3f51b5 98%, ' + referenceMedianColor + ' 2%) !important'}">
+                      v-bind:style="{ background: 'linear-gradient(90deg, #10627a 96%, ' + referenceMedianColor + ' 4%) !important'}">
             <div class="headline">{{antiPattern.name}}</div>
         </v-card-title>
         <v-card-text class="grow">

--- a/src/components/AntiPatternTagsComponent.vue
+++ b/src/components/AntiPatternTagsComponent.vue
@@ -80,6 +80,6 @@
         margin-left: 16px;
         margin-right: 16px;
         height: 15px;
-        background-image: linear-gradient(to right, gray 2%, rgba(0,172,193,0) 2%, rgba(0,172,193,1) 49%);
+        background-image: linear-gradient(to right, gray 2%, rgb(255,165,0,0) 2%, rgb(255,165,0,1) 49%);
     }
 </style>

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -4,11 +4,11 @@ import 'vuetify/dist/vuetify.min.css';
 
 Vue.use(Vuetify, {
     theme: {
-        primary: '#3f51b5',
+        primary: '#10627a',
         secondary: '#455066',
-        accent: '#82B1FF',
+        accent: '#4395AD',
         error: '#FF5252',
-        info: '#2196F3',
+        info: '#4395AD',
         success: '#FFFFFF',
         warning: '#FFC107',
     },

--- a/src/services/EvidenceService.ts
+++ b/src/services/EvidenceService.ts
@@ -34,7 +34,7 @@ export default class EvidenceService {
     public static getReferenceMedianColor(antiPattern: AntiPattern): string {
         if (antiPattern.median) {
             const alphaValue = antiPattern.median / 100 + 0.1;
-            return "rgba(0, 172, 193, " + alphaValue + ")";
+            return "rgb(255, 165, 0, " + alphaValue + ")";
         }
         return "lightgrey";
     }


### PR DESCRIPTION
I sat down with somebody who isn't colorblind like us and talked about the visual design... 🙃 

Color coding configuration could probably be refactored to be changeable in one place, because currently it's pretty spread across several locations as you can see from the changed files. Anyway, this is the result:
![image](https://user-images.githubusercontent.com/3702778/51412130-e0973500-1b6a-11e9-896d-3ae4fba1554f.png)

She said the evidence color piece is still too small to be really noticeable, but in the current implementation it's not really feasible to enlarge it because it will overlap with the title. So maybe we should change that to a horizontal bar under or over the header? 🤔 Not sure...

Oh, and were the toasts/alerts always that small? Did I break them somehow?